### PR TITLE
#11: fix the two Postgres breakages, drop the dead GET /run/{id}

### DIFF
--- a/app/Console/Commands/ImportCsvs.php
+++ b/app/Console/Commands/ImportCsvs.php
@@ -67,7 +67,7 @@ class ImportCsvs extends Command
 	    	preg_match('#\[(.*?)\]#', $runRow['Game'], $nameMatches);
 
 		    $runGame = (isset($nameMatches[1])) ? $nameMatches[1] : $runRow['Game'];
-				$runDate = ($runRow['Scheduled']) ? Date('Y:m:d H:i:s', strtotime($runRow['Scheduled'])) : null;
+				$runDate = ($runRow['Scheduled']) ? Date('Y-m-d H:i:s', strtotime($runRow['Scheduled'])) : null;
 				$runPlatform = ($runRow['Platform']) ? $runRow['Platform'] : null;
 				$runEvent = ($runRow['Event']) ? $runRow['Event'] : null;
 				$runCategory = ($runRow['Category']) ? $runRow['Category'] : null;

--- a/app/Services/Slug.php
+++ b/app/Services/Slug.php
@@ -39,7 +39,7 @@ class Slug
 	protected static function findSimilarSlugs($slug, Model $model)
 	{
 		$query = $model::query();
-		return $query->select('slug')->where('slug', 'like', $slug.'%')
+		return $query->select('slug')->where('slug', 'ilike', $slug.'%')
 		           ->where('id', '<>', $model->getQueueableId())
 		           ->get();
 	}

--- a/routes/web.php
+++ b/routes/web.php
@@ -77,7 +77,6 @@ Route::get('/platform/gbs-emu', function() {
 Route::get('/', [HomeController::class, 'index'])->name('home');
 Route::get('/about', [HomeController::class, 'about'])->name('about');
 
-Route::get('/run/{id}', [RunController::class, 'run']);
 Route::post('/run/{id}', [RunController::class, 'watchedRun']);
 
 Route::get('/event/', [EventController::class, 'index'])->name('events');


### PR DESCRIPTION
Closes the two remaining code breakages in #11, and resolves #14.

Three one-line changes. No schema, config, container or dependency changes — the
Dockerfile and compose files are #12 and are untouched here.

## 1. `ImportCsvs` wrote a date Postgres refuses

`app/Console/Commands/ImportCsvs.php:70` formatted the scheduled date as
`Y:m:d H:i:s` — **colons** in the date portion, producing `2012:08:16 13:00:00`.
MySQL tolerated it for six years. Postgres rejects it, so `runCsv:import` died on
the first row carrying a scheduled date.

Now `Y-m-d H:i:s`, matching `DashboardController`'s upload path, which has always
done it correctly — which is exactly why the HTTP CSV upload worked on Postgres
while the artisan importer did not.

`Y:m:d` appeared **once** in the codebase; that occurrence is now gone. The two
`DashboardController` sites (lines 40 and 53) were already correct and are
unchanged. Nothing reads the format back or depends on the malformed shape.

## 2. `LIKE` is case-sensitive on Postgres

`app/Services/Slug.php:42` matched candidate slugs with `LIKE`, relying on
MySQL's case-insensitive default collation. Postgres `LIKE` is case-sensitive, so
the uniqueness check stopped seeing existing slugs that differ only in case and
quietly began handing out duplicates. `ILIKE` restores the prior behaviour.

This is the only `LIKE` query in `app/`, `routes/`, `database/` or `config/`.

## 3. `GET /run/{id}` deleted (#14)

`routes/web.php` mapped `GET /run/{id}` to `RunController@run`. That method has
never existed — the controller defines only `watchedRun()` — so every GET was a
500, on MySQL and Postgres alike.

**Deleted, per #14's lean.** The evidence says stub, not unfinished page:

- Introduced by `d11a6eb` ("Stub out routes", Nov 2018) and never implemented.
  `RunController` has only ever gained `watchedRun()` (`20fcf29`).
- No `run` view exists — `resources/views/` has `runner.blade.php` and no
  single-run template.
- Nothing links to it. The only consumer of that URI is the `POST` in
  `resources/js/app.js:164` (`watchedRun()`), the watch-tracking call.

The `POST /run/{id}` route is untouched and still works. I found no evidence a
single-run page was intended, so I did not invent one.

## Verification — what I actually ran, and what I did not

**Ran for real.** Both SQL semantics, against a throwaway **PostgreSQL 16.14**
container, using the column types from the real migrations
(`runs.run_date` → `timestamp(0)`, `games.slug` → `varchar(255)`):

| Check | Result |
|---|---|
| `INSERT '2012:08:16 13:00:00'` into `timestamp(0)` | `ERROR: date/time field value out of range` — the old format |
| `INSERT '2012-08-16 13:00:00'` into `timestamp(0)` | `INSERT 0 1` — the fixed format |
| one row slugged `zelda`, `LIKE 'zelda%'` | 1 row |
| one row slugged `zelda`, `LIKE 'Zelda%'` | **0 rows** — the bug |
| one row slugged `zelda`, `ILIKE 'Zelda%'` | 1 row — the fix |

This reproduces the exact failure quoted in #11 and confirms both fixes resolve
it at the level the bugs actually live at.

**Verified by reading, not execution.** PHP is not installed in this environment
and there is no `vendor/`, so nothing PHP-side was executed: the `ImportCsvs`
command was not run, the Slug path was not exercised through
`FirstOrCreateUniqueSlug`, no migrations were run, and no page was loaded. What
that leaves resting on inspection rather than a test run:

- that `date('Y-m-d H:i:s', ...)` emits what Postgres accepted above (it is the
  same format string `DashboardController` already uses successfully on Postgres);
- that Eloquent passes the `ilike` operator through to Postgres unchanged;
- that removing the route breaks no caller — argued from the grep and history
  above rather than from a request.

**Not re-run here.** #11 asks that pages touched by these fixes be re-checked by
hand once they land. #13 already walked every index and detail page, the legacy
slug redirects, `POST /run/{id}`, and the login and password-reset cycles against
Postgres 16. The highest-value follow-up on a machine with PHP is a single
`runCsv:import` against Postgres — it exercises the date fix and drives the slug
fix through `FirstOrCreateUniqueSlug` for games, events, platforms and runners in
one command. The CSV upload endpoint covers the same slug path over HTTP.

## Notes

- `config/filesystems.php` left alone — `ImportCsvs` lists via the `local` disk
  and reads via `storage_path('app/'.$file)`, and #11 flags that those must
  agree.
- `WatchedRun`'s `->where('old', '=', 0)` left alone — #11 retracted that as a
  breakage; Eloquent binds the value and Postgres infers it as boolean.
