### PR TITLE
#29: purge the Cloudflare cache as the deploy's last step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -155,3 +155,28 @@ jobs:
             echo "https://esavods.com$path -> $CODE"
             [ "$CODE" = "200" ] || { echo "::error::expected 200 from $path, got $CODE"; exit 1; }
           done
+
+      # Last step, and deliberately NON-FATAL. By now the release is live and verified; a stale
+      # edge is a smaller problem than a red deploy that teaches people to ignore the pipeline.
+      # It warns loudly and exits 0 - so read the tail of a deploy before believing a
+      # post-deploy visual bug.
+      #
+      # Cloudflare answers HTTP 200 with {"success":false}, so this tests the response BODY.
+      # Exit status alone would pass on a refusal - the same false-green shape as pg_restore
+      # exiting 0 on an empty restore.
+      #
+      # The zone id is baked into authorized_keys on the host, not passed from here: this key
+      # can purge exactly one zone and no other.
+      - name: Purge the Cloudflare cache
+        run: |
+          SSH_KEY="$HOME/.ssh/deploy_key"
+          if ! OUT=$(ssh -i "$SSH_KEY" -o IdentitiesOnly=yes -o BatchMode=yes "root@$DEPLOY_HOST" purge 2>&1); then
+            echo "::warning::purge command failed, the edge may be stale: $OUT"
+            exit 0
+          fi
+          echo "$OUT"
+          if echo "$OUT" | python3 -c 'import json,sys; sys.exit(0 if json.load(sys.stdin).get("success") else 1)' 2>/dev/null; then
+            echo "cache purged"
+          else
+            echo "::warning::Cloudflare did not report success:true, the edge may be stale"
+          fi


### PR DESCRIPTION
Adds the final unchecked item of **PR 2** in the homelab vault's
`Conventions/Deploy Pipeline.md`: the Cloudflare purge, as the deploy's last step.

## Non-fatal on purpose

By the time it runs, the release is live and already verified from the public
internet. A stale edge is a smaller problem than a red deploy that teaches people
to ignore the pipeline — so it **warns and exits 0**. The consequence worth
knowing: read the tail of a deploy log before believing a post-deploy visual bug.

## It tests the body, not the exit status

Cloudflare answers HTTP **200** with `{"success":false}`. Exit status alone passes
on a refusal.

That is the same false-green shape that cost real time three separate times on
2026-08-23: `pg_restore` exits 0 on an empty restore; the fleet's first CI run
reported success on five tests that never executed; and a `Server: cloudflare` 200
turned out to be the old origin. Checking the body is the cheap version of that
lesson.

## The zone id is not passed from here

It is baked into `authorized_keys` on the host, alongside the app uuid. The deploy
key is restricted to a forced command, so the only thing this workflow supplies is
a bare action word matched against an allow-list — meaning **this key can purge
exactly one zone** and redeploy exactly one app.

Verified before the keys were used:

| Attempt | Result |
| --- | --- |
| `deploy` / `status` / `purge` on its own app+zone | permitted |
| `whoami`, `cat /root/.coolify-api-token` | refused |
| interactive shell | PTY allocation failed |
| `deploy <another app's uuid>` | refused |

## Prerequisite, and why this can merge before it

The host wrapper needs its `purge` action — `/root/setup-deploy-keys-v2.sh` on
racknerd installs it and rewrites the three `authorized_keys` entries with their
zone ids.

**Until that runs, this step warns and the deploy still succeeds.** That is the
point of it being non-fatal: the workflow change is safe to land first, and starts
working the moment the wrapper is updated.

Zone ids are recorded in `Conventions/CDN Purge on Deploy.md`, filled in 2026-08-23
from the purge token itself — which turns out to carry `Zone:Read`, a finding noted
there for the next rotation.
