### PR TITLE
#25: guard blank slugs in menu

### DIFF
--- a/app/Providers/MenuServiceProvider.php
+++ b/app/Providers/MenuServiceProvider.php
@@ -51,7 +51,7 @@ class MenuServiceProvider extends ServiceProvider
      */
     protected function menu(): array
     {
-        return Cache::get('menu', function() {
+        $menu = Cache::get('menu', function() {
             $menuArray = [];
             $menuArray['events'] = Event::orderBy('year', 'desc')->orderBy('order', 'asc')->get()->sortByDesc('year')->groupBy('year');
             $menuArray['platforms'] = Platform::orderBy('name', 'asc')->get();
@@ -62,5 +62,23 @@ class MenuServiceProvider extends ServiceProvider
             Cache::put('menu', $menuArray, 60 * 60 * 24);
             return $menuArray;
         });
+
+        // A blank slug makes route('*.show') throw. This menu renders in the shared
+        // layout, so one bad row 500s every page (#25, the 2026-08-25 outage).
+        // Filtered on read, not inside the closure: the cache lives in Postgres and
+        // survives deploys, so a cache warmed before this fix still holds bad rows.
+        $menu['categories'] = collect($menu['categories'])
+            ->filter(fn ($c) => filled($c->slug))->values();
+
+        $menu['platforms'] = collect($menu['platforms'])
+            ->filter(fn ($p) => filled($p->slug))->values();
+
+        // events is grouped by year and each group has ->chunk(2) called on it in the
+        // layout, so each group must stay a Collection. Drop groups left empty.
+        $menu['events'] = collect($menu['events'])
+            ->map(fn ($group) => collect($group)->filter(fn ($e) => filled($e->slug))->values())
+            ->reject(fn ($group) => $group->isEmpty());
+
+        return $menu;
     }
 }

--- a/resources/views/categoryIndex.blade.php
+++ b/resources/views/categoryIndex.blade.php
@@ -32,8 +32,12 @@
 				            <?php /* @var $event \App\Category */ ?>
                             <tr data-id="{{ $category->id }}">
                                 <td nowrap>
-                                    @if(isset($category->name) && isset($category->slug))
-                                        <a href="{{ route('category.show', $category->slug) }}">{{ $category->name }}</a>
+                                    @if(isset($category->name))
+                                        @if(filled($category->slug))
+                                            <a href="{{ route('category.show', $category->slug) }}">{{ $category->name }}</a>
+                                        @else
+                                            {{ $category->name }}
+                                        @endif
                                     @endif
                                 </td>
                                 <td>


### PR DESCRIPTION
## Summary

Closes #25. On 2026-08-25 a single blank-slug `categories` row 500'd every
page on esavods.com for ~29 hours, because `route('category.show', $slug)`
is called from the shared layout with no guard. The data has since been
fixed, but nothing stopped it happening again.

- `app/Providers/MenuServiceProvider.php`: filter blank-slug categories and
  platforms, and drop empty event groups, from the cached menu **on read**
  (outside the `Cache::get` closure). The menu cache lives in Postgres and
  survives deploys, so filtering inside the closure would leave a
  pre-warmed bad cache 500ing the site for up to 24h after this fix lands.
  The cache closure body, TTL, key, and store are unchanged.
- `resources/views/categoryIndex.blade.php`: skip `route('category.show', ...)`
  for a blank slug, rendering the category name as plain text instead of
  dropping the row.

Deliberately out of scope (per the ticket): the other `route('*.show', ...)`
call sites (#38), the error page (#37), and `ImportCsvs` skipping blank
names.

## Test plan

- [x] `php -l` clean on both changed files (via `php:8.3-cli` in Docker)
- [x] Reviewed `layouts/app.blade.php` lines 65-105 and 134-140: `$menu['events']`
      groups and `$menu['platforms']` remain Collections after filtering, so
      `->chunk(2)` and `->chunk(ceil(count(...) / 3))` still work
- [ ] CI (`artisan test` against Postgres 16) on this PR