### PR TITLE
#40 Adopt the fleet local dev interface: make build/test/run/database

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,23 @@
+{
+  "name": "esavods",
+  "dockerComposeFile": ["../docker-compose.yml"],
+  "service": "app",
+  "workspaceFolder": "/var/www/html",
+  "shutdownAction": "stopCompose",
+  // App on 8001, Postgres on 55401 — assigned in the fleet port table so this
+  // and esavods can be up at the same time.
+  "forwardPorts": [8001, 55401],
+  "portsAttributes": {
+    "8001": { "label": "esavods (http)" },
+    "55401": { "label": "esavods (postgres)" }
+  },
+  "features": {
+    "ghcr.io/devcontainers/features/github-cli:1": {}
+  },
+  "postCreateCommand": "bash .devcontainer/setup.sh",
+  "customizations": {
+    "vscode": {
+      "extensions": ["anthropic.claude-code", "bmewburn.vscode-intelephense-client"]
+    }
+  }
+}

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Devcontainer post-create. Idempotent: safe to re-run after a rebuild.
+set -euo pipefail
+
+if [ ! -f .env ]; then
+  echo "==> creating .env from .env.example"
+  cp .env.example .env
+  sed -i 's|^DB_HOST=.*|DB_HOST=db|; s|^DB_PASSWORD=.*|DB_PASSWORD=password|' .env
+fi
+
+echo "==> composer install"
+composer install --no-interaction
+
+grep -qE '^APP_KEY=.+' .env || { echo "==> php artisan key:generate"; php artisan key:generate; }
+
+echo
+echo "Ready. Run 'make' to see the targets."

--- a/.gitattributes
+++ b/.gitattributes
@@ -9,3 +9,5 @@
 /.github export-ignore
 CHANGELOG.md export-ignore
 .styleci.yml export-ignore
+
+Makefile text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@ Thumbs.db
 _ide_helper.php
 npm-debug.log
 yarn-error.log
+
+# Production dumps pulled by `make database download`. Real users, real
+# email addresses, real password hashes — never commit these.
+/backups

--- a/Build/backup-database.sh
+++ b/Build/backup-database.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# `make database download` — fetch this app's newest dump from Cloudflare R2.
+#
+# NOT a live pg_dump over SSH. The nightly backup already produces a verified
+# dump of every app database and puts it in R2 (homelab Conventions/Backups.md),
+# so a dev machine needs no production SSH access and no write path to a live
+# database.
+#
+# Credentials come from a fleet-level READ-ONLY R2 token, shared by every repo:
+#
+#   ~/.config/homelab/backups.env      mode 600, overridable by HOMELAB_BACKUP_ENV
+#     R2_ACCOUNT_ID=
+#     R2_ACCESS_KEY_ID=
+#     R2_SECRET_ACCESS_KEY=
+#     R2_BUCKET=db-backups
+#
+# One shared file, deliberately not this repo's .env: a fleet credential copied
+# per project is maintained in none of them.
+set -euo pipefail
+
+DB_NAME="${DB_NAME:-esavods}"
+DEST_DIR="${DEST_DIR:-backups}"
+CONFIG="${HOMELAB_BACKUP_ENV:-$HOME/.config/homelab/backups.env}"
+
+# Already in the environment wins. `make database download` runs this INSIDE the
+# dev container and passes the credential in with compose's --env-file, because
+# the file lives on the host at ~/.config/homelab and the container cannot see
+# it. Reading the file directly still works when rclone is on your PATH.
+if [ -n "${R2_ACCESS_KEY_ID:-}" ] && [ -n "${R2_SECRET_ACCESS_KEY:-}" ] && [ -n "${R2_ACCOUNT_ID:-}" ]; then
+  :
+elif [ ! -r "$CONFIG" ]; then
+  cat >&2 <<EOF
+error: $CONFIG not readable.
+
+This needs the fleet's READ-ONLY R2 token, which is created by hand:
+  Cloudflare dashboard -> R2 -> Manage API tokens -> Create
+  Object Read only, scoped to the db-backups bucket alone.
+Then write it to $CONFIG (mode 600) and record it in the password manager.
+
+Do NOT copy the credentials from racknerd's /etc/homelab/backup.env — that
+token has write access to the backups.
+EOF
+  exit 1
+else
+  # shellcheck disable=SC1090
+  set -a; . "$CONFIG"; set +a
+fi
+
+for v in R2_ACCOUNT_ID R2_ACCESS_KEY_ID R2_SECRET_ACCESS_KEY; do
+  [ -n "${!v:-}" ] || { echo "error: $v is not set in $CONFIG" >&2; exit 1; }
+done
+R2_BUCKET="${R2_BUCKET:-db-backups}"
+
+command -v rclone >/dev/null || { echo "error: rclone is not installed" >&2; exit 1; }
+
+export RCLONE_CONFIG_R2_TYPE=s3
+export RCLONE_CONFIG_R2_PROVIDER=Cloudflare
+export RCLONE_CONFIG_R2_ACCESS_KEY_ID="$R2_ACCESS_KEY_ID"
+export RCLONE_CONFIG_R2_SECRET_ACCESS_KEY="$R2_SECRET_ACCESS_KEY"
+export RCLONE_CONFIG_R2_ENDPOINT="https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
+
+# The prefix is chosen from the date at WRITE time: the 1st of a month goes to
+# monthly/, Sunday to weekly/, everything else to daily/. So on a Monday the
+# newest object is under weekly/, and looking only in daily/ silently hands you
+# yesterday's data. Search all three.
+#
+# Sorted by the timestamp IN THE NAME, not by mtime. The name carries the UTC
+# instant the dump was taken; mtime is when the upload finished. They usually
+# agree, which is what would make trusting the wrong one survive review.
+echo "==> searching daily/ weekly/ monthly/ for app-${DB_NAME}-*.dump"
+found=""
+for prefix in daily weekly monthly; do
+  listing="$(rclone lsf "R2:${R2_BUCKET}/${prefix}/" 2>/dev/null || true)"
+  [ -n "$listing" ] || continue
+  match="$(printf '%s\n' "$listing" | grep -E "^app-${DB_NAME}-[0-9]{8}-[0-9]{6}\.dump$" || true)"
+  [ -n "$match" ] || continue
+  while IFS= read -r name; do
+    found="${found}${name} ${prefix}"$'\n'
+  done <<< "$match"
+done
+
+if [ -z "$found" ]; then
+  echo "error: no app-${DB_NAME}-*.dump found in any prefix." >&2
+  echo "What IS in the bucket:" >&2
+  for prefix in daily weekly monthly; do
+    rclone lsf "R2:${R2_BUCKET}/${prefix}/" 2>/dev/null \
+      | grep -E '^app-.*\.dump$' | sed "s|^|  ${prefix}/|" >&2 || true
+  done
+  echo >&2
+  echo "\"you asked for a database that is not backed up\" and \"the bucket is empty\"" >&2
+  echo "must not both look like an empty directory." >&2
+  exit 1
+fi
+
+newest="$(printf '%s' "$found" | sort -k1,1 | tail -1)"
+object="$(echo "$newest" | awk '{print $1}')"
+prefix="$(echo "$newest" | awk '{print $2}')"
+remote="R2:${R2_BUCKET}/${prefix}/${object}"
+
+mkdir -p "$DEST_DIR"
+target="${DEST_DIR}/${object}"
+
+# Download to .partial and rename only on success. A connection that dies
+# mid-stream leaves a truncated dump that is non-empty and passes every "is it
+# there?" check, indistinguishable from a good one until restore day.
+echo "==> $remote"
+rclone copyto "$remote" "${target}.partial" --progress
+
+remote_size="$(rclone size "$remote" --json 2>/dev/null | grep -o '"bytes":[0-9]*' | cut -d: -f2)"
+local_size="$(wc -c < "${target}.partial" | tr -d ' ')"
+if [ -n "$remote_size" ] && [ "$remote_size" != "$local_size" ]; then
+  rm -f "${target}.partial"
+  echo "error: size mismatch — remote $remote_size, local $local_size" >&2
+  exit 1
+fi
+
+# pg_dump -Fc archives start with the magic string PGDMP. Same check the backup
+# writer makes before storing anything.
+if [ "$(head -c 5 "${target}.partial")" != "PGDMP" ]; then
+  rm -f "${target}.partial"
+  echo "error: ${object} has no PGDMP header — not a pg_dump -Fc archive" >&2
+  exit 1
+fi
+
+mv "${target}.partial" "$target"
+echo "==> $target ($local_size bytes, verified)"
+echo
+echo "This is production data: real users, real email addresses, real password"
+echo "hashes. backups/ is gitignored; delete it when you are done with it."

--- a/Build/migrate-database.sh
+++ b/Build/migrate-database.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# `make database migrate` — bring the restored schema forward to this branch.
+#
+# Runs AFTER restore, not instead of it: the newest nightly dump is up to a day
+# behind whatever migrations are on the branch you are working on.
+set -euo pipefail
+
+COMPOSE="${COMPOSE:-docker compose}"
+APP_SERVICE="${APP_SERVICE:-app}"
+
+$COMPOSE up -d "$APP_SERVICE"
+$COMPOSE exec -T "$APP_SERVICE" php artisan migrate --force

--- a/Build/restore-database.sh
+++ b/Build/restore-database.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# `make database restore` — drop and recreate the target database from the
+# newest dump in backups/.
+#
+# This DROPS a database. Correct against a disposable dev volume, catastrophic
+# against the shared instance, and the only thing between the two is an
+# environment variable — so it refuses any non-local host unless
+# ALLOW_REMOTE_RESTORE=1 is typed on purpose.
+#
+# The client runs inside the app container (that is where psql is), but it
+# connects to DB_HOST over the network rather than `compose exec`-ing into the
+# db service. That matters: an earlier version guarded on DB_HOST while always
+# operating on the compose service, so ALLOW_REMOTE_RESTORE=1 with a remote host
+# wiped the LOCAL database and reported it as a remote restore. The check and
+# the target must be the same thing or the check is theatre.
+set -euo pipefail
+
+COMPOSE="${COMPOSE:-docker compose}"
+APP_SERVICE="${APP_SERVICE:-app}"
+DB_SERVICE="${DB_SERVICE:-db}"
+SRC_DIR="${SRC_DIR:-backups}"
+
+env_get() { grep -E "^$1=" .env 2>/dev/null | head -1 | cut -d= -f2- | tr -d '"'"'"'\r'; }
+
+DB_HOST="${DB_HOST:-$(env_get DB_HOST)}";         DB_HOST="${DB_HOST:-db}"
+DB_NAME="${DB_NAME:-$(env_get DB_DATABASE)}";     DB_NAME="${DB_NAME:-esavods}"
+DB_USER="${DB_USER:-$(env_get DB_USERNAME)}";     DB_USER="${DB_USER:-esavods}"
+DB_PASS="${DB_PASS:-$(env_get DB_PASSWORD)}";     DB_PASS="${DB_PASS:-password}"
+DB_PORT_="${DB_PORT_:-$(env_get DB_PORT)}";       DB_PORT_="${DB_PORT_:-5432}"
+
+case "$DB_HOST" in
+  localhost|127.0.0.1|::1|"$DB_SERVICE") ;;
+  *)
+    if [ "${ALLOW_REMOTE_RESTORE:-}" != "1" ]; then
+      echo "error: DB_HOST is '$DB_HOST', which is not local." >&2
+      echo "restore DROPS the database. Against the shared instance that is production gone." >&2
+      echo "If you truly mean it: ALLOW_REMOTE_RESTORE=1 make database restore" >&2
+      exit 1
+    fi
+    echo "!! ALLOW_REMOTE_RESTORE=1 — this will DROP '$DB_NAME' on '$DB_HOST'" >&2
+    ;;
+esac
+
+dump="$(ls -1 "$SRC_DIR"/app-*.dump 2>/dev/null | sort | tail -1 || true)"
+[ -n "$dump" ] || { echo "error: no $SRC_DIR/app-*.dump — run 'make database download' first" >&2; exit 1; }
+
+# Say what is about to be destroyed, before destroying it.
+echo "==> restoring $(basename "$dump")"
+echo "    into database '$DB_NAME' on host '$DB_HOST:$DB_PORT_' as '$DB_USER'"
+echo "    this DROPS and recreates that database"
+echo
+
+$COMPOSE up -d "$DB_SERVICE" >/dev/null 2>&1 || true
+
+psql_in() {
+  $COMPOSE run --rm -T --no-deps -e DB_HOST= -e PGPASSWORD="$DB_PASS" \
+    "$APP_SERVICE" psql -h "$DB_HOST" -p "$DB_PORT_" -U "$DB_USER" "$@"
+}
+
+psql_in -d postgres \
+  -c "DROP DATABASE IF EXISTS \"$DB_NAME\" WITH (FORCE);" \
+  -c "CREATE DATABASE \"$DB_NAME\" OWNER \"$DB_USER\";"
+
+$COMPOSE run --rm -T --no-deps -e DB_HOST= -e PGPASSWORD="$DB_PASS" \
+  "$APP_SERVICE" pg_restore -h "$DB_HOST" -p "$DB_PORT_" -U "$DB_USER" \
+  -d "$DB_NAME" --no-owner --no-privileges < "$dump"
+
+# pg_restore exits 0 on an empty restore, so the exit code proves nothing on its
+# own. Count what actually landed.
+tables="$(psql_in -d "$DB_NAME" -tAc "select count(*) from information_schema.tables where table_schema='public';" | tr -d ' \r')"
+rows="$(psql_in -d "$DB_NAME" -tAc "select coalesce(sum(n_live_tup),0)::bigint from pg_stat_user_tables;" | tr -d ' \r')"
+echo
+echo "==> restored: $tables tables, ~$rows rows"
+[ "${tables:-0}" -gt 0 ] || { echo "error: restore produced no tables" >&2; exit 1; }
+echo "    run 'make database migrate' — the dump is up to a day behind this branch"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,46 @@ repository.
 esavods.com — a Laravel 12 app (PHP `^8.3`) deployed to production via Coolify, on push to
 `master`.
 
+## Local dev interface
+
+`make` is the interface, and it lives **inside the devcontainer** — PHP and `make` are neither of
+them on the Windows host. The fleet-wide table and reasoning live in the `homelab` vault at
+`Conventions/Local Dev Interface.md`; restated here because that vault is private.
+
+| | |
+| --- | --- |
+| `make` | List the targets. `.DEFAULT_GOAL := help` |
+| `make build` | Build the dev image |
+| `make test` | The suite, against a throwaway Postgres — see the warning below |
+| `make run` | Serve on **8001**, Postgres on **55401**, URL printed last |
+| `make database download restore migrate` | Newest R2 dump → local database → schema forward |
+
+**Ports 8001 / 55401 are assigned, not defaulted.** `PORT=` and **`DB_HOST_PORT=`** override. This
+repo moved off 8080, and its Postgres off 5432 — which speedrunwr also publishes, so they could not
+previously run at the same time.
+
+`DB_HOST_PORT`, not `DB_PORT`: compose substitutes from this repo's `.env`, where Laravel's
+`DB_PORT=5432` is the *internal* connection port.
+
+> [!CAUTION]
+> **Never run the suite through the `app` service.** `docker compose run app php artisan test` can
+> wipe a real database. `env_file: .env` puts `DB_*` into the container's real OS environment;
+> Laravel's `env()` reads `$_SERVER` while PHPUnit's `<env name="DB_CONNECTION" value="sqlite"/>`
+> only sets `$_ENV`/`putenv()`, so `phpunit.xml` never wins — `force="true"` included. That is #22.
+>
+> `make test` uses the separate `test` service: no `env_file`, an explicit environment block, and a
+> **tmpfs** `test-db`. It also logs to stderr, because it runs as root over the shared bind mount
+> and a file log leaves a root-owned `storage/logs/laravel.log` that php-fpm cannot write —
+> `make run` then 500s and the cause is nowhere near the symptom.
+
+`make database download` reads the nightly backup from R2, not a live `pg_dump` over SSH. It wants
+the **read-only** fleet R2 token at `~/.config/homelab/backups.env` — not this repo's `.env`.
+`backups/` is gitignored: those dumps are production data.
+
+The postgres client is pinned to **`postgresql16-client`**, matching the server. `pg_restore`
+rebuilds the dump's SQL preamble from the *client's* version, so a floating 18.x client emits
+`SET transaction_timeout` that the 16.x server rejects.
+
 ## Work queue
 
 Work lives in this repo's **GitHub Issues**, one issue per item, with exactly one `type:` label

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,15 @@
 ########################################################################
 FROM php:8.3-fpm-alpine AS base
 
+# postgresql16-client is PINNED to the server's major version, not the floating
+# `postgresql-client`. pg_restore reconstructs the dump's SQL preamble using the
+# CLIENT's version, so an 18.x client emits `SET transaction_timeout`, which the
+# 16.x server rejects - every restore then reports an error it can do nothing
+# about, and pg_restore exits non-zero over it. Matches speedrunwr, which
+# already pinned this.
 RUN apk add --no-cache \
         nginx \
-        postgresql-client \
+        postgresql16-client \
         icu-libs \
         libpq \
         libzip \
@@ -53,7 +59,19 @@ WORKDIR /var/www/html
 ########################################################################
 FROM base AS dev
 
-RUN apk add --no-cache git unzip bash
+RUN apk add --no-cache git unzip bash curl
+
+# rclone for `make database download`, pinned and taken from upstream rather
+# than the distro package. The version racknerd's backup installer pins, for the
+# same reason: 1.60 fails its first attempt against R2 with 501 NotImplemented
+# and only succeeds on retry.
+ARG RCLONE_VERSION=v1.75.0
+RUN curl -fsSL -o /tmp/rclone.zip \
+      "https://downloads.rclone.org/${RCLONE_VERSION}/rclone-${RCLONE_VERSION}-linux-amd64.zip" \
+ && unzip -oq /tmp/rclone.zip -d /tmp \
+ && install -m 755 "/tmp/rclone-${RCLONE_VERSION}-linux-amd64/rclone" /usr/local/bin/rclone \
+ && rm -rf /tmp/rclone.zip "/tmp/rclone-${RCLONE_VERSION}-linux-amd64"
+
 COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
 
 COPY docker/entrypoint-dev.sh /usr/local/bin/entrypoint-dev.sh

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,95 @@
+# Primary CLI surface for esavods. Each target is a thin wrapper over docker
+# compose or artisan; see CLAUDE.md.
+#
+# The fleet interface is `make build test run` plus `make database` across every
+# app repo — TheShrug/homelab Conventions/Local Dev Interface.md.
+
+# Assigned in the fleet port table, not defaulted, so two apps can run at once.
+PORT         ?= 8001
+# DB_HOST_PORT, not DB_PORT: compose substitutes from .env, where Laravel's
+# DB_PORT=5432 is the app's INTERNAL connection port. See docker-compose.yml.
+DB_HOST_PORT ?= 55401
+export PORT DB_HOST_PORT
+
+COMPOSE      := docker compose
+TEST_COMPOSE := docker compose --profile test
+
+DB_ACTIONS := download restore migrate
+
+# The fleet's read-only R2 credential, on the HOST. `download` runs inside the
+# dev container (that is where rclone is), so it is passed in with compose's
+# --env-file rather than mounted — one fewer host path baked into compose, and
+# it keeps working whatever ~ resolves to on this machine.
+HOMELAB_BACKUP_ENV ?= $(HOME)/.config/homelab/backups.env
+
+.DEFAULT_GOAL := help
+.PHONY: help build test run database $(DB_ACTIONS)
+
+help: ## Show this help
+	@echo "esavods — make targets:"
+	@grep -hE '^[a-zA-Z_-]+:.*?## ' $(MAKEFILE_LIST) \
+	  | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-10s %s\n", $$1, $$2}'
+	@echo
+	@echo "  stop the stack with: docker compose down"
+
+.env:
+	@echo "==> no .env, creating one from .env.example"
+	@cp .env.example .env
+	@sed -i 's|^DB_HOST=.*|DB_HOST=db|; s|^DB_PASSWORD=.*|DB_PASSWORD=password|' .env
+	@# DB_HOST is emptied deliberately: docker/entrypoint-dev.sh blocks on
+	@# pg_isready whenever DB_HOST is set, so --no-deps without this hangs
+	@# forever waiting for a database that was never started.
+	@$(COMPOSE) run --rm -T --no-deps -e DB_HOST= app php artisan key:generate
+
+build: ## Build the dev image
+	$(COMPOSE) build
+
+# NOT `docker compose run app php artisan test`. The `app` service carries
+# env_file: .env, which puts DB_* into the container's real OS environment;
+# Laravel's env() reads $_SERVER and phpunit.xml's <env> does not win, so
+# RefreshDatabase truncates whatever `app` points at. That is #14. The `test`
+# service has an explicit environment block and its own tmpfs Postgres.
+#
+# --fail-on-warning is not optional: CI's first green run reported success with
+# five Feature tests that never executed.
+test: ## Run the suite against a throwaway Postgres — never the dev database
+	$(TEST_COMPOSE) run --rm -T test php artisan test --fail-on-warning
+
+run: .env ## Serve the app on 8002 (override PORT=); prints the URL last
+	@$(COMPOSE) up -d
+	@printf '==> waiting for http://localhost:$(PORT)/ '
+	@for _ in $$(seq 1 60); do \
+	   if curl -sfo /dev/null "http://localhost:$(PORT)/"; then break; fi; \
+	   printf '.'; sleep 2; \
+	 done; echo
+	@$(COMPOSE) exec -T app php artisan migrate --force >/dev/null 2>&1 || true
+	@echo
+	@echo "  esavods serving on http://localhost:$(PORT)/  (postgres on $(DB_HOST_PORT))"
+
+# `download` runs INSIDE the dev container, because that is where rclone is.
+# The credential is sourced on the host and passed through with bare `-e NAME`:
+# the file lives at ~/.config/homelab and the container cannot see it,
+# `compose run` has no --env-file, and bare -e keeps the values off the command
+# line where ps would show them.
+# -e DB_HOST= because entrypoint-dev.sh blocks on pg_isready when DB_HOST is set.
+database: ## Run one or more DB actions in order, e.g. `make database download restore migrate`
+	@actions="$(filter $(DB_ACTIONS),$(MAKECMDGOALS))"; \
+	if [ -z "$$actions" ]; then \
+		echo "usage: make database <action> [<action> ...]  (actions: $(DB_ACTIONS))" >&2; \
+		exit 1; \
+	fi; \
+	for action in $$actions; do \
+		case "$$action" in \
+			download) set -a; . "$(HOMELAB_BACKUP_ENV)"; set +a; \
+			  $(COMPOSE) run --rm -T --no-deps -e DB_HOST= \
+			    -e R2_ACCOUNT_ID -e R2_ACCESS_KEY_ID -e R2_SECRET_ACCESS_KEY -e R2_BUCKET \
+			    app ./Build/backup-database.sh ;; \
+			restore)  ./Build/restore-database.sh ;; \
+			migrate)  ./Build/migrate-database.sh ;; \
+		esac; \
+	done
+
+# Swallow the action words so `make database download` doesn't also try to build
+# a literal target named "download".
+$(DB_ACTIONS):
+	@:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,8 +14,12 @@ services:
       interval: 5s
       timeout: 5s
       retries: 10
+    # DB_HOST_PORT, deliberately NOT DB_PORT. Compose substitutes from this
+    # repo's .env, where Laravel's DB_PORT=5432 is the port the app uses to reach
+    # the db service INTERNALLY — so ${DB_PORT:-55401} would publish Postgres on
+    # 5432 and collide with speedrunwr. Assigned in the fleet port table.
     ports:
-      - "5432:5432"
+      - "${DB_HOST_PORT:-55401}:5432"
 
   app:
     build:
@@ -25,11 +29,76 @@ services:
       - .:/var/www/html
     env_file:
       - .env
+    # Moved off 8080 by TheShrug/homelab#39.
     ports:
-      - "8080:80"
+      - "${PORT:-8001}:80"
     depends_on:
       db:
         condition: service_healthy
+
+  # `make test` runs HERE, not on `app`, and the difference is load-bearing.
+  #
+  # `app` carries `env_file: .env`, which puts DB_* into the container's real OS
+  # environment. Laravel's env() reads $_SERVER; phpunit.xml's
+  # <env name="DB_CONNECTION" value="sqlite"/> only sets $_ENV/putenv() and does
+  # not win - force="true" included, verified. RefreshDatabase then migrates and
+  # truncates whatever the container points at. That is #22.
+  #
+  # So this service has NO env_file. Configuration comes from the explicit block
+  # below and nowhere else, mirroring .github/workflows/ci.yml.
+  test:
+    build:
+      context: .
+      target: dev
+    volumes:
+      - .:/var/www/html
+    environment:
+      APP_ENV: testing
+      APP_DEBUG: "true"
+      # A throwaway key, committed on purpose. It encrypts nothing that outlives
+      # the run and it is not production's. CI generates a fresh one per job
+      # (ci.yml "Generate a throwaway APP_KEY"); a fixed one here keeps `make
+      # test` from depending on openssl being on whatever host invoked it.
+      # Without it the suite dies on MissingAppKeyException, because this
+      # service deliberately has no env_file to inherit APP_KEY from.
+      APP_KEY: "base64:ITo1xE3Y/E9S3MIk+1Wu39nqPugtcXVdY6ljzsKSsVk="
+      DB_CONNECTION: pgsql
+      DB_HOST: test-db
+      DB_PORT: "5432"
+      DB_DATABASE: testing
+      DB_USERNAME: postgres
+      DB_PASSWORD: postgres
+      SESSION_DRIVER: array
+      CACHE_STORE: array
+      QUEUE_CONNECTION: sync
+      MAIL_MAILER: array
+      # stderr, not the default single-file channel. This service runs as root
+      # and shares the bind mount with `app`, so a file log leaves a root-owned
+      # storage/logs/laravel.log that php-fpm (www-data) then cannot write —
+      # `make run` starts 500ing after `make test`, and the cause is nowhere
+      # near the symptom. CI logs to stderr for the same reason.
+      LOG_CHANNEL: stderr
+    depends_on:
+      test-db:
+        condition: service_healthy
+    profiles: ["test"]
+
+  # Throwaway by construction: tmpfs, no named volume, and NOT the `db` service
+  # that `make run` seeds from a production dump.
+  test-db:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_DB: testing
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    tmpfs:
+      - /var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 2s
+      timeout: 3s
+      retries: 30
+    profiles: ["test"]
 
 volumes:
   esavods-db-data:

--- a/docker/entrypoint-dev.sh
+++ b/docker/entrypoint-dev.sh
@@ -1,10 +1,17 @@
 #!/bin/sh
 set -e
 
-until pg_isready -h "$DB_HOST" -p "${DB_PORT:-5432}" -U "$DB_USERNAME" -d "$DB_DATABASE" >/dev/null 2>&1; do
-    echo "Waiting for Postgres at $DB_HOST:${DB_PORT:-5432}..."
-    sleep 1
-done
+# Guarded on DB_HOST, matching speedrunwr's entrypoint. Unguarded, this loops
+# forever for any invocation that deliberately has no database - `make database
+# download` runs in this container to reach rclone and never touches Postgres,
+# and an unset DB_HOST made it hang instead of failing. Converged rather than
+# worked around, per homelab Conventions/Container Shape.
+if [ -n "$DB_HOST" ]; then
+    until pg_isready -h "$DB_HOST" -p "${DB_PORT:-5432}" -U "$DB_USERNAME" -d "$DB_DATABASE" >/dev/null 2>&1; do
+        echo "Waiting for Postgres at $DB_HOST:${DB_PORT:-5432}..."
+        sleep 1
+    done
+fi
 
 if [ -f composer.json ] && [ ! -d vendor ]; then
     composer install


### PR DESCRIPTION
Closes #40, and the practical half of #22. Part of TheShrug/homelab#39.

| | |
| --- | --- |
| `make build` | build the dev image |
| `make test` | the suite, against a **throwaway** Postgres |
| `make run` | serve on **8001**, Postgres on **55401**, URL printed last |
| `make database download restore migrate` | newest R2 dump → local db → schema forward |

Shape copied from speedrunwr on purpose — same Makefile, same `Build/` scripts,
same test-service pattern. Four things here were genuinely different, and each
would have broken a blind copy.

## What was different, and why it mattered

**The entrypoint looped unconditionally on `pg_isready`.** speedrunwr guards on
`DB_HOST`. `make database download` runs in this container to reach rclone and
never touches Postgres, so an unset `DB_HOST` hung forever instead of
proceeding. Converged with speedrunwr rather than worked around.

**Ports were 8080 and 5432.** The 5432 is the collision the fleet table exists to
prevent — speedrunwr published it too, so the two could not run at once. Now
8001 / 55401, via `DB_HOST_PORT` rather than `DB_PORT`, because compose
substitutes from `.env` where Laravel's `DB_PORT=5432` is the *internal* port.

**`postgresql-client` was unpinned**, and Alpine now resolves it to **18.6**.
`pg_restore` rebuilds the dump's SQL preamble from the *client's* version, so an
18.x client emits `SET transaction_timeout` that the 16.15 server rejects: every
restore reported an error, and `pg_restore`'s non-zero exit aborted the script
before it could count rows. Pinned to `postgresql16-client`.

**The test service needed `APP_KEY` and `LOG_CHANNEL`.** Neither is obvious until
it's run. Without `APP_KEY` the suite dies on `MissingAppKeyException`, because
this service deliberately has no `env_file`; CI generates a throwaway per job, so
a fixed throwaway is committed here. Without `LOG_CHANNEL=stderr` the root-owned
test process leaves a root-owned `storage/logs/laravel.log` in the shared bind
mount that php-fpm (www-data) cannot write — **`make run` starts 500ing after
`make test`**, with the cause nowhere near the symptom. Both have been
backported to speedrunwr, where they were latent.

## Verified by running it

- **download** fetched `app-esavods-20260828-180553.dump`, newest across
  `daily/` `weekly/` `monthly/`, 249,592 bytes checked against the remote size
  and the `PGDMP` header
- **restore**: 17 tables, ~11,637 rows
- **test**: 2 passed, and **watched failing once** — planted assertion exits 1,
  removed exits 0
- **test does not touch the dev database**: canary user planted, still present
  afterwards, `runs` unchanged at 1,762
- **`make run`** serves 200 on 8001 with a real rendered page (316 KB of events,
  not an empty schema)
- **esavods and speedrunwr up at the same time** — 8001 and 8002, Postgres on
  55401 and 55402, no collision. That was the acceptance criterion this ticket
  shared with speedrunwr#31
